### PR TITLE
change hash collision resolution to linear probing to remove dynamic allocations

### DIFF
--- a/src/map.h
+++ b/src/map.h
@@ -976,11 +976,6 @@ typedef struct TileHashEntry {
    * Pointer to the data associated with the tile.
    */
   void *data;
-  /**
-   * Pointer to the next entry in the bucket. This will only be set if there is
-   * a hashing coflict between two positions.
-   */
-  struct TileHashEntry *next;
 } TileHashEntry;
 
 
@@ -1005,11 +1000,6 @@ typedef struct TileOverrideHashEntry {
    * Override for the tile palette.
    */
   uint8_t palette;
-  /**
-   * Pointer to the next entry in the bucket. This will only be set if there is
-   * a hashing coflict between two positions.
-   */
-  struct TileOverrideHashEntry *next;
 } TileOverrideHashEntry;
 
 /**

--- a/src/map.h
+++ b/src/map.h
@@ -937,6 +937,7 @@ typedef struct FloorBank {
 
 /**
  * Number of entries in the map object hash table.
+ * This must be a power of two for index wrapping logic.
  */
 #define TILE_HASHTABLE_SIZE 64
 


### PR DESCRIPTION
By modifying the separate chaining hash collision resolution to [linear probing](https://en.wikipedia.org/wiki/Linear_probing), dynamic allocation (and more generally, stdlib.h) is no longer necessary.  This will change the usage of `tile_object_hashtable` and `tile_override_hashtable` and will require `TILE_HASHTABLE_SIZE` to be increased if a floor contains more than 64 (the current size) objects or overrides.

I successfully completed floors one and two with these changes, but additional testing is definitely required to increase confidence in this change.