### PR TITLE
The torch chest is now empty if you already have the torch.

### DIFF
--- a/assets/strings.js
+++ b/assets/strings.js
@@ -183,6 +183,7 @@ addNamespace('maps', 2, {
   'chest_unlock_key': "You unlock the chest with a magic key!",
   'get_magic_key': "You get a magic key!",
   'get_torch': "You find a torch!",
+  'already_has_torch': "The chest is empty!",
   'lever_stuck': "It's stuck!",
   'lever_one_way': "Seems this lever was one and done.",
   'door_locked': 'The door is locked.',

--- a/src/floor_common.c
+++ b/src/floor_common.c
@@ -18,6 +18,8 @@ bool chest_add_torch(Chest *chest) {
   if (is_chest_locked(chest->id)) {
     map_textbox(str_maps_chest_locked);
     return false;
+  } else if (player.has_torch) {
+    map_textbox(str_maps_already_has_torch);
   } else {
     player.has_torch = true;
     map_textbox(str_maps_get_torch);


### PR DESCRIPTION
I like the idea of the player being able to keep the torch so they can avoid encounters when working back through the first level after they die. So I made the chest be empty if you already have it.

Closes #64 