### PR TITLE
show MP/SP as appropriate in level up message

### DIFF
--- a/assets/strings.js
+++ b/assets/strings.js
@@ -115,6 +115,7 @@ addNamespace('battle', 3, {
   'player_confused_mumble': 'You mumble some gibberish and giggle a little.',
   'victory': 'Victory! You gain %exp XP!',
   'victory_no_xp': 'Victory! But you gain no XP...',
+  'level_up': 'LEVEL UP! Welcome\nto level %level!\n\nHP+%cP restored!',
 })
 
 addNamespace('player', 4, {

--- a/src/encounter.c
+++ b/src/encounter.c
@@ -569,9 +569,9 @@ void set_player_item(ItemId item_id) {
 
 void apply_rewards(void) {
   if (level_up(encounter.xp_reward)) {
-    const char *format = "LEVEL UP! Welcome\nto level %u!\n\nHP+MP restored!";
     play_sound(sfx_level_up);
-    sprintf(rewards_buf, format, player.level);
+    sprintf(rewards_buf, str_battle_level_up, player.level,
+      is_magic_class() ? 'M' : 'S');
     return;
   }
 

--- a/tools/strings2c
+++ b/tools/strings2c
@@ -184,6 +184,15 @@ function encodeString(namespace, key, str, debugOn=false) {
 
   imr.forEach(rep => {
     debug('Compiling IMR', rep);
+
+    // Don't try to line-wrap on a newline character.
+    if (rep.encoded == "\\n") {
+      currentLineLen = 0;
+      result += '\\n';
+      addLength(1);
+      return;
+    }
+
     if (currentLineLen + rep.length > maxLineLength) {
       debug('Line length exceeded, adding \\n');
       currentLineLen = 0;


### PR DESCRIPTION
There are two fixes in this proposed change:

1. Prevent strings2c from line-wrapping on a newline character to better support pre-wrapped data strings.
2. Check [is_magic_class()](https://github.com/NesHacker/LabyrinthOfTheDragon/blob/main/src/player.h#L345) to show MP or SP in level up message as appropriate.

Confirmed that no existing data string is modified with this change.
Confirmed MP is shown for Sorcerer and SP is shown for Monk.

This fixes https://github.com/NesHacker/LabyrinthOfTheDragon/issues/69.