### PR TITLE
spelling: Fix a swath of spelling mistakes.

### DIFF
--- a/src/battle.c
+++ b/src/battle.c
@@ -86,7 +86,7 @@ static bool is_screen_shaking = false;
 
 /**
  * Finds the monster currently selected by the screen cursor.
- * @return Monster intance for the selected monster.
+ * @return Monster instance for the selected monster.
  */
 static Monster *get_monster_at_cursor(void) {
   uint8_t monster_idx = 0;
@@ -233,7 +233,7 @@ static void toggle_hp_bar_palette(MonsterPosition pos) {
 /**
  * Draws an HP bar for the monster at a given position.
  * @param pos Position of the monster on the battle screen.
- * @param hp Curent HP for the monster.
+ * @param hp Current HP for the monster.
  * @param max Max HP for the monster.
  */
 static void draw_hp_bar(MonsterPosition pos, uint16_t hp, uint16_t max) {
@@ -809,7 +809,7 @@ static void redraw_submenu_text(void) {
 }
 
 /**
- * Initalizes a submenu for the given entry lines and number of entries.
+ * Initializes a submenu for the given entry lines and number of entries.
  * @param lines Line buffers to draw.
  * @param entries Total number of entries for the battle_menu.
  */

--- a/src/battle.h
+++ b/src/battle.h
@@ -195,7 +195,7 @@ typedef enum BattleState {
    */
   BATTLE_NEXT_TURN,
   /**
-   * Enitity status effects are updated, effects applied, and messages provided
+   * Entity status effects are updated, effects applied, and messages provided
    * for specific actions (e.g. effect falls off, regen health, etc.)
    */
   BATTLE_UPDATE_STATUS_EFFECTS,
@@ -242,7 +242,7 @@ typedef enum BattleState {
    */
   BATTLE_UI_UPDATE,
   /**
-   * Battle is over and successful, calulates & displays rewards, etc.
+   * Battle is over and successful, calculates & displays rewards, etc.
    */
   BATTLE_SUCCESS,
   /**

--- a/src/item.h
+++ b/src/item.h
@@ -90,7 +90,7 @@ inline uint8_t clear_inventory(void) {
 bool can_use_item(ItemId id);
 
 /**
- * Uses an item. Only performs the action for the item, inventory quantitiy
+ * Uses an item. Only performs the action for the item, inventory quantity
  * state must be managed with `remove_item`.
  * @param item Item to use.
  */

--- a/src/map.c
+++ b/src/map.c
@@ -52,7 +52,7 @@ uint8_t move_step;
 int8_t vram_x;
 
 /**
- * Curren VRAM progressive load origin y-position.
+ * Current VRAM progressive load origin y-position.
  */
 int8_t vram_y;
 
@@ -67,7 +67,7 @@ uint8_t buffer_pos;
 uint8_t buffer_max;
 
 /**
- * VRAM start colum to use during a progressive load.
+ * VRAM start column to use during a progressive load.
  */
 int8_t vram_col;
 
@@ -124,7 +124,7 @@ Timer flame_timer;
 uint8_t flame_frame;
 
 /**
- * Timer used to slowly reduce the amount of torch guage remaining.
+ * Timer used to slowly reduce the amount of torch gauge remaining.
  */
 Timer torch_timer;
 
@@ -526,8 +526,8 @@ static TileOverrideHashEntry *find_override_entry(
  *       and palettes. Turns out hashing (0,7,29) OR (0,9,26) OR (0,9,29) all
  *       hash to 58.
  *
- *       *SOMEHOW* the collsion is not bucketing correctly and it's causing an
- *       error where the tile for the wrong position gets overriden?
+ *       *SOMEHOW* the collision is not bucketing correctly and it's causing an
+ *       error where the tile for the wrong position gets overridden?
  *
  *       I am "fixing" this due to lack of time by shifting the tiles in level
  *       7's main floor so the collisions no longer take place. *sigh*

--- a/src/map.h
+++ b/src/map.h
@@ -61,22 +61,22 @@
 #define TORCH_GAUGE_FLAME 24
 
 /**
- * Sprite id for the torch gauge body positon 1.
+ * Sprite id for the torch gauge body position 1.
  */
 #define TORCH_GAUGE_BODY_1 25
 
 /**
- * Sprite id for the torch gauge body positon 2.
+ * Sprite id for the torch gauge body position 2.
  */
 #define TORCH_GAUGE_BODY_2 26
 
 /**
- * Sprite id for the torch gauge body positon 3.
+ * Sprite id for the torch gauge body position 3.
  */
 #define TORCH_GAUGE_BODY_3 27
 
 /**
- * Sprite id for the torch gauge body positon 4.
+ * Sprite id for the torch gauge body position 4.
  */
 #define TORCH_GAUGE_BODY_4 28
 
@@ -285,7 +285,7 @@ typedef enum MapId {
  */
 typedef enum MapTileAttribute {
   /**
-   * Denotes an impassible wall.
+   * Denotes an impassable wall.
    */
   MAP_WALL,
   /**
@@ -365,7 +365,7 @@ typedef enum HeroState {
 } HeroState;
 
 /**
- * Main state enumaration for the world map controller.
+ * Main state enumeration for the world map controller.
  */
 typedef enum MapState {
   /**
@@ -386,7 +386,7 @@ typedef enum MapState {
    */
   MAP_STATE_FADE_OUT,
   /**
-   * Denotes that the graphics are fading back in after a progessive map/area
+   * Denotes that the graphics are fading back in after a progressive map/area
    * load.
    */
   MAP_STATE_FADE_IN,
@@ -967,7 +967,7 @@ typedef struct TileHashEntry {
    */
   int8_t x;
   /**
-   * Vertical positon for the associated tile in the map.
+   * Vertical position for the associated tile in the map.
    */
   int8_t y;
   /**
@@ -991,7 +991,7 @@ typedef struct TileOverrideHashEntry {
    */
   int8_t x;
   /**
-   * Vertical positon for the associated tile in the map.
+   * Vertical position for the associated tile in the map.
    */
   int8_t y;
   /**
@@ -1056,7 +1056,7 @@ extern MapState map_state;
 extern int8_t map_x;
 
 /**
- * Veritcal map coordinate.
+ * Vertical map coordinate.
  */
 extern int8_t map_y;
 
@@ -1180,7 +1180,7 @@ inline void set_map_position(int8_t x, int8_t y) {
 
 /**
  * Sets position of map based on hero position. Does not re-render the map. You
- * must call `refresh_map_screen()` or load the screen progresively.
+ * must call `refresh_map_screen()` or load the screen progressively.
  */
 inline void set_hero_position(int8_t x, int8_t y) {
   map_x = x - HERO_X_OFFSET;
@@ -1211,7 +1211,7 @@ void draw_world_map(void);
 
 /**
  * Initiates battle using the currently configured encounter. This should be
- * called by area handlers to start battle after initalizing the `encounter`
+ * called by area handlers to start battle after initializing the `encounter`
  * state used by the battle system.
  */
 inline void start_battle(void) {

--- a/src/monster.h
+++ b/src/monster.h
@@ -122,7 +122,7 @@ typedef struct Monster {
    */
   uint8_t matk_base;
   /**
-   * Current magical attack. Calculed via status effects, etc.
+   * Current magical attack. Calculated via status effects, etc.
    */
   uint8_t matk;
   /**

--- a/src/player.h
+++ b/src/player.h
@@ -229,7 +229,7 @@ typedef struct Player {
    */
   FlameColor torch_color;
   /**
-   * Number of magic keys the player currently posesses.
+   * Number of magic keys the player currently possesses.
    */
   uint8_t magic_keys;
   /**

--- a/src/stats.h
+++ b/src/stats.h
@@ -493,14 +493,14 @@ inline bool is_fumble(uint8_t d16_roll) {
 /**
  * @return `true` If immune to the given effect.
  * @param immune Immunity bitfield.
- * @param effec Status effect to check.
+ * @param effect Status effect to check.
  */
 inline bool is_debuff_immmune(uint8_t immune, StatusEffect effect) {
   return immune & FLAG(effect);
 }
 
 /**
- * Caluclates if a scared entity flees or not.
+ * Calculates if a scared entity flees or not.
  * @param tier Tier of the scared debuff.
  * @return `
  */

--- a/src/text_writer.h
+++ b/src/text_writer.h
@@ -145,7 +145,7 @@ typedef struct TextWriter {
    */
   void (*print)(const char *string);
   /**
-   * Called to proceeed to the next page. Calling this outside of a page wait
+   * Called to proceed to the next page. Calling this outside of a page wait
    * will clear the screen and continue printing characters.
    */
   void (*next_page)(void);


### PR DESCRIPTION
These were all caught with codespell.  There are still warnings about 'Aspect' - but those are actually the correctly used word 'aspect', so not changing that.