### PR TITLE
Fixing floor 3 encounter layout

### DIFF
--- a/src/floor3.c
+++ b/src/floor3.c
@@ -322,7 +322,7 @@ static const EncounterTable encounters_low[] = {
 // Max Level: 23
 static const EncounterTable encounters_high[] = {
   {
-    ODDS_20P, MONSTER_LAYOUT_2,
+    ODDS_20P, MONSTER_LAYOUT_1,
     MONSTER_ZOMBIE, 21, A_TIER,
   },
   {


### PR DESCRIPTION
Fixing the lowest roll encounter table entry for high level floor 3 encounters.  This was previously loading a zero'd out Kobold (since `MONSTER_KOBOLD` == 0) into the second slot, which could do massive damage.

Alternatively, the layout could remain the same if another monster is added to the table.  This is a game balance decision.

Addresses https://github.com/NesHacker/LabyrinthOfTheDragon/issues/78.